### PR TITLE
DecisionTree bestguess compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - 10-compatibility-with-decisiontree-package
     tags: ['*']
   pull_request:
   workflow_dispatch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SoleBase"
 uuid = "4475fa32-7023-44a0-aa70-4813b230e492"
 authors = ["Federico Manzella", "Patrik Cavina", "Eduard I. Stan", "Lorenzo Balboni", "Giovanni Pagliarini"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/machine-learning-utils.jl
+++ b/src/machine-learning-utils.jl
@@ -52,6 +52,7 @@ end
         labels::AbstractVector{<:Label},
         weights::Union{Nothing,AbstractVector} = nothing;
         suppress_parity_warning = false,
+        parity_func = sort(collect(counts), by = x -> x[1])[1][1]
     )
 
 Return the best guess for a set of labels; that is, the label that best approximates the
@@ -67,15 +68,17 @@ See also
 """
 function bestguess(
     labels::AbstractVector{<:Label},
-    weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = false,
+    weights::Union{Nothing, AbstractVector}=nothing;
+    suppress_parity_warning=false,
+    parity_func=x->argmax(x)
 ) end
 
 # Classification: (weighted) majority vote
 function bestguess(
     labels::AbstractVector{<:CLabel},
-    weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = false,
+    weights::Union{Nothing, AbstractVector}=nothing;
+    suppress_parity_warning=false,
+    parity_func=x->argmax(x)
 )
     if length(labels) == 0
         return nothing
@@ -99,10 +102,8 @@ function bestguess(
                   "counts ($(length(labels)) elements): $(counts), " *
                   "argmax: $(argmax(counts)), " *
                   "max: $(counts[argmax(counts)]) (sum = $(sum(values(counts))))"
-        ) 
-        # To be compatible with DecisionTree we need to pick up,
-        # in case of parity, the first key in alphabetical order
-        sort(collect(counts), by = x->x[1])[1][1]
+        )
+        parity_func(counts)
     else
         argmax(counts)
     end
@@ -111,8 +112,9 @@ end
 # Regression: (weighted) mean (or other central tendency measure?)
 function bestguess(
     labels::AbstractVector{<:RLabel},
-    weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = false,
+    weights::Union{Nothing, AbstractVector}=nothing;
+    suppress_parity_warning=false,
+    parity_func=x->(x)
 )
     if length(labels) == 0
         return nothing

--- a/src/machine-learning-utils.jl
+++ b/src/machine-learning-utils.jl
@@ -51,7 +51,7 @@ end
     bestguess(
         labels::AbstractVector{<:Label},
         weights::Union{Nothing,AbstractVector} = nothing;
-        suppress_parity_warning = true,
+        suppress_parity_warning = false,
     )
 
 Return the best guess for a set of labels; that is, the label that best approximates the
@@ -68,14 +68,14 @@ See also
 function bestguess(
     labels::AbstractVector{<:Label},
     weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = true,
+    suppress_parity_warning = false,
 ) end
 
 # Classification: (weighted) majority vote
 function bestguess(
     labels::AbstractVector{<:CLabel},
     weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = true,
+    suppress_parity_warning = false,
 )
     if length(labels) == 0
         return nothing
@@ -112,7 +112,7 @@ end
 function bestguess(
     labels::AbstractVector{<:RLabel},
     weights::Union{Nothing, AbstractVector} = nothing;
-    suppress_parity_warning = true,
+    suppress_parity_warning = false,
 )
     if length(labels) == 0
         return nothing

--- a/test/machine_learning_utils.jl
+++ b/test/machine_learning_utils.jl
@@ -2,7 +2,7 @@
     
     @testset "Type Definitions" begin
         @test SoleBase.XGLabel == Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
-        @test SoleBase.CLabel == Union{AbstractString, CategoricalValue}
+        @test SoleBase.CLabel == Union{AbstractString, Symbol, CategoricalValue}
         @test SoleBase.RLabel == Real
         @test SoleBase.Label == Union{SoleBase.CLabel, SoleBase.RLabel}
     end
@@ -41,9 +41,12 @@
         @test SoleBase.bestguess(cat_labels) isa CategoricalValue{String, UInt32}
         @test SoleBase.bestguess(cat_labels) == "x"
 
-        # Test parity warning suppression
+        # Test that parity warning is shown when not suppressed
         parity_labels = ["a", "b"]
-        @test_nowarn SoleBase.bestguess(parity_labels, suppress_parity_warning=false)
+        @test_logs (:warn, r"Parity encountered in bestguess!") SoleBase.bestguess(parity_labels, suppress_parity_warning=false)
+
+        # Test parity warning suppression
+        @test_nowarn SoleBase.bestguess(parity_labels, suppress_parity_warning=true)
     end
     
     @testset "bestguess - Regression" begin

--- a/test/machine_learning_utils.jl
+++ b/test/machine_learning_utils.jl
@@ -43,7 +43,7 @@
 
         # Test parity warning suppression
         parity_labels = ["a", "b"]
-        @test_nowarn SoleBase.bestguess(parity_labels, suppress_parity_warning=true)
+        @test_nowarn SoleBase.bestguess(parity_labels, suppress_parity_warning=false)
     end
     
     @testset "bestguess - Regression" begin


### PR DESCRIPTION
To be compatible with DecisionTree we need to pick up, in case of parity, the first key in alphabetical order

what's changed:
- added symbol to const CLabel.
- changed suppress_parity_warining default to true.
- changed behaviour of bestguess for classification tasks:
 now, if parity is encourtered, will return the first in alphabetical order, like DecisionTree package.

to do:
- add tests 