### PR TITLE
get rid of _CLabel and _Label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - devModal
     tags: ['*']
   pull_request:
   workflow_dispatch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SoleBase"
 uuid = "4475fa32-7023-44a0-aa70-4813b230e492"
 authors = ["Federico Manzella", "Patrik Cavina", "Eduard I. Stan", "Lorenzo Balboni", "Giovanni Pagliarini"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/machine-learning-utils.jl
+++ b/src/machine-learning-utils.jl
@@ -5,7 +5,6 @@ using CategoricalArrays
 
 doc_supervised_ml = """
     const XGLabel = Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
-    const XGLabel = Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
     const CLabel  = Union{AbstractString,Integer,CategoricalValue}
     const RLabel  = AbstractFloat
     const Label   = Union{CLabel,RLabel}
@@ -16,15 +15,11 @@ Types for supervised machine learning labels (classification and regression).
 """$(doc_supervised_ml)"""
 const XGLabel = Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
 """$(doc_supervised_ml)"""
-const CLabel = Union{AbstractString, Symbol, CategoricalValue}
+const CLabel = Union{AbstractString, Symbol, CategoricalValue, UInt32}
 """$(doc_supervised_ml)"""
 const RLabel = Real
 """$(doc_supervised_ml)"""
 const Label = Union{CLabel, RLabel}
-
-# Raw labels
-const _CLabel = Integer # (classification labels are internally represented as integers)
-const _Label = Union{_CLabel, RLabel}
 
 ############################################################################################
 
@@ -37,7 +32,7 @@ Base.@propagate_inbounds @inline function get_categorical_form(Y::AbstractVector
         @inbounds dict[class_names[i]] = i
     end
 
-    _Y = Array{Int64}(undef, length(Y))
+    _Y = Array{UInt32}(undef, length(Y))
     @simd for i in 1:length(Y)
         @inbounds _Y[i] = dict[Y[i]]
     end

--- a/test/machine_learning_utils.jl
+++ b/test/machine_learning_utils.jl
@@ -2,7 +2,7 @@
     
     @testset "Type Definitions" begin
         @test SoleBase.XGLabel == Tuple{Union{AbstractString, Integer, CategoricalValue}, Real}
-        @test SoleBase.CLabel == Union{AbstractString, Symbol, CategoricalValue}
+        @test SoleBase.CLabel == Union{AbstractString, Symbol, CategoricalValue, UInt32}
         @test SoleBase.RLabel == Real
         @test SoleBase.Label == Union{SoleBase.CLabel, SoleBase.RLabel}
     end


### PR DESCRIPTION
Using ModalDecisionTrees, we need to propagate the type of labes (usually a vector called Y) to automatically discern between classification or regression tasks.
Even if those tasks seem to require very different type of labels, there's one type that conjunct them: Int64.
In our case, Int64 is used inside ModalDecisionTrees, also in classification task, switching from a vector of, i.e. "strings", to a vector of Int64, for classification and further calculations.
To do that it's used an utility that come from this package.
I propose to change the output of that function, from an original `Vector{Int64` to `Vectori{UInt32}`, just like CategoricalArrays package.